### PR TITLE
Ensure files created by `quarto create` are user-writable

### DIFF
--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -1,3 +1,7 @@
 All changes included in 1.10:
 
+## Commands
 
+### `quarto create`
+
+- Fix `quarto create` producing read-only files when Quarto is installed via system packages (e.g., `.deb`). Files copied from installed resources now have user-write permission ensured.

--- a/news/changelog-1.10.md
+++ b/news/changelog-1.10.md
@@ -4,4 +4,4 @@ All changes included in 1.10:
 
 ### `quarto create`
 
-- Fix `quarto create` producing read-only files when Quarto is installed via system packages (e.g., `.deb`). Files copied from installed resources now have user-write permission ensured.
+- ([#14250](https://github.com/quarto-dev/quarto-cli/issues/14250)): Fix `quarto create` producing read-only files when Quarto is installed via system packages (e.g., `.deb`). Files copied from installed resources now have user-write permission ensured.

--- a/src/command/create/artifacts/artifact-shared.ts
+++ b/src/command/create/artifacts/artifact-shared.ts
@@ -12,10 +12,25 @@ import { gfmAutoIdentifier } from "../../../core/pandoc/pandoc-id.ts";
 import { coerce } from "semver/mod.ts";
 import { info } from "../../../deno_ral/log.ts";
 import { basename, dirname, join, relative } from "../../../deno_ral/path.ts";
-import { ensureDirSync, walkSync } from "../../../deno_ral/fs.ts";
+import {
+  ensureDirSync,
+  safeChmodSync,
+  safeModeFromFile,
+  walkSync,
+} from "../../../deno_ral/fs.ts";
 import { renderEjs } from "../../../core/ejs.ts";
 import { safeExistsSync } from "../../../core/path.ts";
 import { CreateDirective, CreateDirectiveData } from "../cmd-types.ts";
+
+// Ensure a copied file has user write permission.
+// Files copied from installed resources may be read-only,
+// but users expect to edit files created by `quarto create`.
+function ensureUserWritable(path: string) {
+  const mode = safeModeFromFile(path);
+  if (mode !== undefined && !(mode & 0o200)) {
+    safeChmodSync(path, mode | 0o200);
+  }
+}
 
 // File paths that include this string will get fixed up
 // and the value from the ejs data will be substituted
@@ -116,6 +131,7 @@ const renderArtifact = (
     }
     ensureDirSync(dirname(target));
     Deno.copyFileSync(src, target);
+    ensureUserWritable(target);
     return target;
   }
 };

--- a/src/command/create/artifacts/artifact-shared.ts
+++ b/src/command/create/artifacts/artifact-shared.ts
@@ -14,23 +14,12 @@ import { info } from "../../../deno_ral/log.ts";
 import { basename, dirname, join, relative } from "../../../deno_ral/path.ts";
 import {
   ensureDirSync,
-  safeChmodSync,
-  safeModeFromFile,
+  ensureUserWritable,
   walkSync,
 } from "../../../deno_ral/fs.ts";
 import { renderEjs } from "../../../core/ejs.ts";
 import { safeExistsSync } from "../../../core/path.ts";
 import { CreateDirective, CreateDirectiveData } from "../cmd-types.ts";
-
-// Ensure a copied file has user write permission.
-// Files copied from installed resources may be read-only,
-// but users expect to edit files created by `quarto create`.
-function ensureUserWritable(path: string) {
-  const mode = safeModeFromFile(path);
-  if (mode !== undefined && !(mode & 0o200)) {
-    safeChmodSync(path, mode | 0o200);
-  }
-}
 
 // File paths that include this string will get fixed up
 // and the value from the ejs data will be substituted

--- a/src/deno_ral/fs.ts
+++ b/src/deno_ral/fs.ts
@@ -191,3 +191,15 @@ export function safeChmodSync(path: string, mode: number): void {
     }
   }
 }
+
+/**
+ * Ensure a file has user write permission. Files copied from installed
+ * resources (e.g. system packages) may be read-only, but users expect
+ * to edit files created by `quarto create`. No-op on Windows.
+ */
+export function ensureUserWritable(path: string): void {
+  const mode = safeModeFromFile(path);
+  if (mode !== undefined && !(mode & 0o200)) {
+    safeChmodSync(path, mode | 0o200);
+  }
+}

--- a/src/project/project-create.ts
+++ b/src/project/project-create.ts
@@ -26,6 +26,17 @@ import { ensureGitignore } from "./project-gitignore.ts";
 import { kWebsite } from "./types/website/website-constants.ts";
 import { copyTo } from "../core/copy.ts";
 import { normalizePath } from "../core/path.ts";
+import { safeChmodSync, safeModeFromFile } from "../deno_ral/fs.ts";
+
+// Ensure a copied file has user write permission.
+// Files copied from installed resources may be read-only,
+// but users expect to edit files created by `quarto create`.
+function ensureUserWritable(path: string) {
+  const mode = safeModeFromFile(path);
+  if (mode !== undefined && !(mode & 0o200)) {
+    safeChmodSync(path, mode | 0o200);
+  }
+}
 
 export interface ProjectCreateOptions {
   dir: string;
@@ -139,6 +150,7 @@ export async function projectCreate(options: ProjectCreateOptions) {
       if (!existsSync(dest)) {
         ensureDirSync(dirname(dest));
         copyTo(src, dest);
+        ensureUserWritable(dest);
         if (!options.quiet) {
           info("- Created " + displayName, { indent: 2 });
         }
@@ -256,6 +268,7 @@ function projectMarkdownFile(
       const name = basename(from);
       const target = join(dirname(path), name);
       copyTo(from, target);
+      ensureUserWritable(target);
     });
 
     return subdirectory ? join(subdirectory, name) : name;

--- a/src/project/project-create.ts
+++ b/src/project/project-create.ts
@@ -5,7 +5,11 @@
  */
 
 import * as ld from "../core/lodash.ts";
-import { ensureDirSync, existsSync } from "../deno_ral/fs.ts";
+import {
+  ensureDirSync,
+  ensureUserWritable,
+  existsSync,
+} from "../deno_ral/fs.ts";
 import { basename, dirname, join } from "../deno_ral/path.ts";
 import { info } from "../deno_ral/log.ts";
 
@@ -26,17 +30,6 @@ import { ensureGitignore } from "./project-gitignore.ts";
 import { kWebsite } from "./types/website/website-constants.ts";
 import { copyTo } from "../core/copy.ts";
 import { normalizePath } from "../core/path.ts";
-import { safeChmodSync, safeModeFromFile } from "../deno_ral/fs.ts";
-
-// Ensure a copied file has user write permission.
-// Files copied from installed resources may be read-only,
-// but users expect to edit files created by `quarto create`.
-function ensureUserWritable(path: string) {
-  const mode = safeModeFromFile(path);
-  if (mode !== undefined && !(mode & 0o200)) {
-    safeChmodSync(path, mode | 0o200);
-  }
-}
 
 export interface ProjectCreateOptions {
   dir: string;

--- a/tests/smoke/create/create.test.ts
+++ b/tests/smoke/create/create.test.ts
@@ -6,16 +6,11 @@
 */
 
 import { execProcess } from "../../../src/core/process.ts";
-import { dirname, fromFileUrl, join } from "../../../src/deno_ral/path.ts";
+import { join } from "../../../src/deno_ral/path.ts";
 import { walkSync } from "../../../src/deno_ral/fs.ts";
 import { CreateResult } from "../../../src/command/create/cmd-types.ts";
 import { assert } from "testing/asserts";
 import { quartoDevCmd } from "../../utils.ts";
-
-// Resolve the repo's resource directory from the test file location.
-// tests/smoke/create/create.test.ts → src/resources/
-const testDir = dirname(fromFileUrl(import.meta.url));
-const resourceDir = join(testDir, "..", "..", "..", "src", "resources");
 
 const kCreateTypes: Record<string, string[]> = {
   "project": ["website", "default", "book", "website:blog"],
@@ -128,91 +123,4 @@ for (const type of Object.keys(kCreateTypes)) {
       Deno.removeSync(artifactPath, { recursive: true });
     });
   }
-}
-
-// Test that simulates read-only resource files (as found in Nix/deb installs).
-// Makes source template files read-only before running quarto create, then
-// verifies that output files are still user-writable.
-if (Deno.build.os !== "windows") {
-  Deno.test(
-    "quarto create extension filter - read-only source files",
-    async (t) => {
-      const templateDir = join(resourceDir, "create", "extensions", "filter");
-      const sourceFiles: { path: string; originalMode: number }[] = [];
-
-      // Collect all files and make them read-only
-      await t.step("> make source templates read-only", () => {
-        for (const entry of walkSync(templateDir)) {
-          if (entry.isFile) {
-            const stat = Deno.statSync(entry.path);
-            if (stat.mode !== null) {
-              sourceFiles.push({
-                path: entry.path,
-                originalMode: stat.mode!,
-              });
-              Deno.chmodSync(entry.path, stat.mode! & ~0o222);
-            }
-          }
-        }
-        // Verify at least one file was made read-only
-        assert(
-          sourceFiles.length > 0,
-          "Should have found template files to make read-only",
-        );
-      });
-
-      try {
-        // Create the extension from read-only sources
-        const artifactPath = join(tempDir, "readonly-filter-test");
-        const createDirective = {
-          type: "extension",
-          directive: {
-            directory: artifactPath,
-            template: "filter",
-            name: "readonlyfiltertest",
-          },
-        };
-
-        await t.step("> quarto create with read-only sources", async () => {
-          const cmd = [quartoDevCmd(), "create", "--json"];
-          const stdIn = JSON.stringify(createDirective);
-          const process = await execProcess({
-            cmd: cmd[0],
-            args: cmd.slice(1),
-            stdout: "piped",
-            stderr: "piped",
-          }, stdIn);
-          assert(process.success, process.stderr);
-        });
-
-        // Verify all output files are user-writable
-        await t.step("> verify output files are writable", () => {
-          let fileCount = 0;
-          for (const entry of walkSync(artifactPath)) {
-            if (entry.isFile) {
-              const stat = Deno.statSync(entry.path);
-              assert(
-                stat.mode !== null && (stat.mode! & 0o200) !== 0,
-                `File ${entry.path} is not user-writable (mode: ${stat.mode?.toString(8)})`,
-              );
-              fileCount++;
-            }
-          }
-          assert(fileCount > 0, "Should have created at least one file");
-        });
-
-        // Cleanup artifact
-        Deno.removeSync(artifactPath, { recursive: true });
-      } finally {
-        // Always restore original permissions
-        for (const { path, originalMode } of sourceFiles) {
-          try {
-            Deno.chmodSync(path, originalMode);
-          } catch {
-            // Best-effort restore
-          }
-        }
-      }
-    },
-  );
 }

--- a/tests/smoke/create/create.test.ts
+++ b/tests/smoke/create/create.test.ts
@@ -62,7 +62,11 @@ for (const type of Object.keys(kCreateTypes)) {
         assert(process.success, process.stderr);
       });
 
-      // Verify all created files are user-writable
+      // Verify all created files are user-writable.
+      // NOTE: In dev environments, resource files are already writable (0o644),
+      // so this test passes even without ensureUserWritable. It guards against
+      // regressions; the unit test in file-permissions.test.ts covers the
+      // read-only → writable transition directly.
       if (Deno.build.os !== "windows") {
         await t.step(`> check writable ${type} ${template}`, () => {
           for (const entry of walkSync(artifactPath)) {

--- a/tests/smoke/create/create.test.ts
+++ b/tests/smoke/create/create.test.ts
@@ -6,11 +6,16 @@
 */
 
 import { execProcess } from "../../../src/core/process.ts";
-import { join } from "../../../src/deno_ral/path.ts";
+import { dirname, fromFileUrl, join } from "../../../src/deno_ral/path.ts";
 import { walkSync } from "../../../src/deno_ral/fs.ts";
 import { CreateResult } from "../../../src/command/create/cmd-types.ts";
 import { assert } from "testing/asserts";
 import { quartoDevCmd } from "../../utils.ts";
+
+// Resolve the repo's resource directory from the test file location.
+// tests/smoke/create/create.test.ts → src/resources/
+const testDir = dirname(fromFileUrl(import.meta.url));
+const resourceDir = join(testDir, "..", "..", "..", "src", "resources");
 
 const kCreateTypes: Record<string, string[]> = {
   "project": ["website", "default", "book", "website:blog"],
@@ -123,4 +128,91 @@ for (const type of Object.keys(kCreateTypes)) {
       Deno.removeSync(artifactPath, { recursive: true });
     });
   }
+}
+
+// Test that simulates read-only resource files (as found in Nix/deb installs).
+// Makes source template files read-only before running quarto create, then
+// verifies that output files are still user-writable.
+if (Deno.build.os !== "windows") {
+  Deno.test(
+    "quarto create extension filter - read-only source files",
+    async (t) => {
+      const templateDir = join(resourceDir, "create", "extensions", "filter");
+      const sourceFiles: { path: string; originalMode: number }[] = [];
+
+      // Collect all files and make them read-only
+      await t.step("> make source templates read-only", () => {
+        for (const entry of walkSync(templateDir)) {
+          if (entry.isFile) {
+            const stat = Deno.statSync(entry.path);
+            if (stat.mode !== null) {
+              sourceFiles.push({
+                path: entry.path,
+                originalMode: stat.mode!,
+              });
+              Deno.chmodSync(entry.path, stat.mode! & ~0o222);
+            }
+          }
+        }
+        // Verify at least one file was made read-only
+        assert(
+          sourceFiles.length > 0,
+          "Should have found template files to make read-only",
+        );
+      });
+
+      try {
+        // Create the extension from read-only sources
+        const artifactPath = join(tempDir, "readonly-filter-test");
+        const createDirective = {
+          type: "extension",
+          directive: {
+            directory: artifactPath,
+            template: "filter",
+            name: "readonlyfiltertest",
+          },
+        };
+
+        await t.step("> quarto create with read-only sources", async () => {
+          const cmd = [quartoDevCmd(), "create", "--json"];
+          const stdIn = JSON.stringify(createDirective);
+          const process = await execProcess({
+            cmd: cmd[0],
+            args: cmd.slice(1),
+            stdout: "piped",
+            stderr: "piped",
+          }, stdIn);
+          assert(process.success, process.stderr);
+        });
+
+        // Verify all output files are user-writable
+        await t.step("> verify output files are writable", () => {
+          let fileCount = 0;
+          for (const entry of walkSync(artifactPath)) {
+            if (entry.isFile) {
+              const stat = Deno.statSync(entry.path);
+              assert(
+                stat.mode !== null && (stat.mode! & 0o200) !== 0,
+                `File ${entry.path} is not user-writable (mode: ${stat.mode?.toString(8)})`,
+              );
+              fileCount++;
+            }
+          }
+          assert(fileCount > 0, "Should have created at least one file");
+        });
+
+        // Cleanup artifact
+        Deno.removeSync(artifactPath, { recursive: true });
+      } finally {
+        // Always restore original permissions
+        for (const { path, originalMode } of sourceFiles) {
+          try {
+            Deno.chmodSync(path, originalMode);
+          } catch {
+            // Best-effort restore
+          }
+        }
+      }
+    },
+  );
 }

--- a/tests/smoke/create/create.test.ts
+++ b/tests/smoke/create/create.test.ts
@@ -7,6 +7,7 @@
 
 import { execProcess } from "../../../src/core/process.ts";
 import { join } from "../../../src/deno_ral/path.ts";
+import { walkSync } from "../../../src/deno_ral/fs.ts";
 import { CreateResult } from "../../../src/command/create/cmd-types.ts";
 import { assert } from "testing/asserts";
 import { quartoDevCmd } from "../../utils.ts";
@@ -60,6 +61,21 @@ for (const type of Object.keys(kCreateTypes)) {
         }
         assert(process.success, process.stderr);
       });
+
+      // Verify all created files are user-writable
+      if (Deno.build.os !== "windows") {
+        await t.step(`> check writable ${type} ${template}`, () => {
+          for (const entry of walkSync(artifactPath)) {
+            if (entry.isFile) {
+              const stat = Deno.statSync(entry.path);
+              assert(
+                stat.mode !== null && (stat.mode! & 0o200) !== 0,
+                `File ${entry.path} is not user-writable (mode: ${stat.mode?.toString(8)})`,
+              );
+            }
+          }
+        });
+      }
 
       // Render the artifact
       await t.step(`> render ${type} ${template}`, async () => {

--- a/tests/smoke/create/create.test.ts
+++ b/tests/smoke/create/create.test.ts
@@ -67,8 +67,10 @@ for (const type of Object.keys(kCreateTypes)) {
       // so this test passes even without ensureUserWritable. It guards against
       // regressions; the unit test in file-permissions.test.ts covers the
       // read-only → writable transition directly.
-      if (Deno.build.os !== "windows") {
-        await t.step(`> check writable ${type} ${template}`, () => {
+      await t.step({
+        name: `> check writable ${type} ${template}`,
+        ignore: Deno.build.os === "windows",
+        fn: () => {
           for (const entry of walkSync(artifactPath)) {
             if (entry.isFile) {
               const stat = Deno.statSync(entry.path);
@@ -78,8 +80,8 @@ for (const type of Object.keys(kCreateTypes)) {
               );
             }
           }
-        });
-      }
+        },
+      });
 
       // Render the artifact
       await t.step(`> render ${type} ${template}`, async () => {

--- a/tests/unit/file-permissions.test.ts
+++ b/tests/unit/file-permissions.test.ts
@@ -13,66 +13,61 @@ import {
 } from "../../src/deno_ral/fs.ts";
 
 const isWindows = Deno.build.os === "windows";
+const permContext = { ignore: isWindows };
+
+function withTempDir(fn: (dir: string) => void) {
+  const tempDir = Deno.makeTempDirSync({ prefix: "quarto-perm-test" });
+  try {
+    fn(tempDir);
+  } finally {
+    // Ensure all files are writable so cleanup succeeds (e.g. read-only sources)
+    for (const entry of Deno.readDirSync(tempDir)) {
+      try {
+        Deno.chmodSync(join(tempDir, entry.name), 0o644);
+      } catch { /* best effort */ }
+    }
+    Deno.removeSync(tempDir, { recursive: true });
+  }
+}
+
+function writeFile(dir: string, name: string, content: string, mode: number): string {
+  const path = join(dir, name);
+  Deno.writeTextFileSync(path, content);
+  Deno.chmodSync(path, mode);
+  return path;
+}
 
 unitTest(
   "file-permissions - ensureUserWritable fixes read-only files",
   // deno-lint-ignore require-await
-  async () => {
-    const tempDir = Deno.makeTempDirSync({ prefix: "quarto-perm-test" });
-    try {
-      const testFile = join(tempDir, "readonly.txt");
-      Deno.writeTextFileSync(testFile, "test content");
+  async () => withTempDir((dir) => {
+    const file = writeFile(dir, "readonly.txt", "test content", 0o444);
 
-      // Make file read-only (simulate system-installed resource)
-      Deno.chmodSync(testFile, 0o444);
+    const modeBefore = safeModeFromFile(file);
+    assert(modeBefore !== undefined);
+    assert((modeBefore! & 0o200) === 0, "File should be read-only before fix");
 
-      const modeBefore = safeModeFromFile(testFile);
-      assert(modeBefore !== undefined);
-      assert(
-        (modeBefore! & 0o200) === 0,
-        "File should be read-only before fix",
-      );
+    ensureUserWritable(file);
 
-      ensureUserWritable(testFile);
-
-      const modeAfter = safeModeFromFile(testFile);
-      assertEquals(
-        modeAfter,
-        0o644,
-        "Mode should be exactly 0o644 (0o444 | 0o200) — only user write bit added",
-      );
-    } finally {
-      Deno.removeSync(tempDir, { recursive: true });
-    }
-  },
-  { ignore: isWindows },
+    assertEquals(safeModeFromFile(file), 0o644,
+      "Mode should be exactly 0o644 (0o444 | 0o200) — only user write bit added");
+  }),
+  permContext,
 );
 
 unitTest(
   "file-permissions - ensureUserWritable leaves writable files unchanged",
   // deno-lint-ignore require-await
-  async () => {
-    const tempDir = Deno.makeTempDirSync({ prefix: "quarto-perm-test" });
-    try {
-      const testFile = join(tempDir, "writable.txt");
-      Deno.writeTextFileSync(testFile, "test content");
-      Deno.chmodSync(testFile, 0o644);
+  async () => withTempDir((dir) => {
+    const file = writeFile(dir, "writable.txt", "test content", 0o644);
+    const modeBefore = safeModeFromFile(file);
 
-      const modeBefore = safeModeFromFile(testFile);
+    ensureUserWritable(file);
 
-      ensureUserWritable(testFile);
-
-      const modeAfter = safeModeFromFile(testFile);
-      assertEquals(
-        modeAfter,
-        modeBefore,
-        "Mode should be unchanged for already-writable file",
-      );
-    } finally {
-      Deno.removeSync(tempDir, { recursive: true });
-    }
-  },
-  { ignore: isWindows },
+    assertEquals(safeModeFromFile(file), modeBefore,
+      "Mode should be unchanged for already-writable file");
+  }),
+  permContext,
 );
 
 // Simulates the Nix/deb scenario: Deno.copyFileSync from a read-only source
@@ -80,40 +75,22 @@ unitTest(
 unitTest(
   "file-permissions - copyFileSync from read-only source then ensureUserWritable",
   // deno-lint-ignore require-await
-  async () => {
-    const tempDir = Deno.makeTempDirSync({ prefix: "quarto-perm-test" });
-    try {
-      // Create a "source resource" file and make it read-only
-      const src = join(tempDir, "source.lua");
-      Deno.writeTextFileSync(src, "-- filter code");
-      Deno.chmodSync(src, 0o444);
+  async () => withTempDir((dir) => {
+    const src = writeFile(dir, "source.lua", "-- filter code", 0o444);
 
-      // Copy it (this is what quarto create does internally)
-      const dest = join(tempDir, "dest.lua");
-      Deno.copyFileSync(src, dest);
+    // Copy it (this is what quarto create does internally)
+    const dest = join(dir, "dest.lua");
+    Deno.copyFileSync(src, dest);
 
-      // Without the fix, dest inherits 0o444 from src
-      const modeBefore = safeModeFromFile(dest);
-      assert(modeBefore !== undefined);
-      assert(
-        (modeBefore! & 0o200) === 0,
-        "Copied file should inherit read-only mode from source",
-      );
+    // Without the fix, dest inherits 0o444 from src
+    const modeBefore = safeModeFromFile(dest);
+    assert(modeBefore !== undefined);
+    assert((modeBefore! & 0o200) === 0, "Copied file should inherit read-only mode from source");
 
-      // Apply the fix
-      ensureUserWritable(dest);
+    ensureUserWritable(dest);
 
-      const modeAfter = safeModeFromFile(dest);
-      assertEquals(
-        modeAfter,
-        0o644,
-        "Copied file should be user-writable after ensureUserWritable",
-      );
-    } finally {
-      // Restore write on source so cleanup succeeds
-      Deno.chmodSync(join(tempDir, "source.lua"), 0o644);
-      Deno.removeSync(tempDir, { recursive: true });
-    }
-  },
-  { ignore: isWindows },
+    assertEquals(safeModeFromFile(dest), 0o644,
+      "Copied file should be user-writable after ensureUserWritable");
+  }),
+  permContext,
 );

--- a/tests/unit/file-permissions.test.ts
+++ b/tests/unit/file-permissions.test.ts
@@ -1,0 +1,75 @@
+/*
+ * file-permissions.test.ts
+ *
+ * Copyright (C) 2020-2025 Posit Software, PBC
+ */
+
+import { unitTest } from "../test.ts";
+import { assert, assertEquals } from "testing/asserts";
+import {
+  ensureUserWritable,
+  safeModeFromFile,
+} from "../../src/deno_ral/fs.ts";
+
+unitTest(
+  "file-permissions - ensureUserWritable fixes read-only files",
+  // deno-lint-ignore require-await
+  async () => {
+    if (Deno.build.os === "windows") return;
+
+    const tempDir = Deno.makeTempDirSync({ prefix: "quarto-perm-test" });
+    try {
+      const testFile = `${tempDir}/readonly.txt`;
+      Deno.writeTextFileSync(testFile, "test content");
+
+      // Make file read-only (simulate system-installed resource)
+      Deno.chmodSync(testFile, 0o444);
+
+      const modeBefore = safeModeFromFile(testFile);
+      assert(modeBefore !== undefined);
+      assert(
+        (modeBefore! & 0o200) === 0,
+        "File should be read-only before fix",
+      );
+
+      ensureUserWritable(testFile);
+
+      const modeAfter = safeModeFromFile(testFile);
+      assert(modeAfter !== undefined);
+      assert(
+        (modeAfter! & 0o200) !== 0,
+        "File should be user-writable after fix",
+      );
+    } finally {
+      Deno.removeSync(tempDir, { recursive: true });
+    }
+  },
+);
+
+unitTest(
+  "file-permissions - ensureUserWritable leaves writable files unchanged",
+  // deno-lint-ignore require-await
+  async () => {
+    if (Deno.build.os === "windows") return;
+
+    const tempDir = Deno.makeTempDirSync({ prefix: "quarto-perm-test" });
+    try {
+      const testFile = `${tempDir}/writable.txt`;
+      Deno.writeTextFileSync(testFile, "test content");
+      Deno.chmodSync(testFile, 0o644);
+
+      const modeBefore = safeModeFromFile(testFile);
+
+      ensureUserWritable(testFile);
+
+      const modeAfter = safeModeFromFile(testFile);
+      assertEquals(
+        modeAfter,
+        modeBefore,
+        "Mode should be unchanged for already-writable file",
+      );
+    } finally {
+      Deno.removeSync(tempDir, { recursive: true });
+    }
+  },
+);

--- a/tests/unit/file-permissions.test.ts
+++ b/tests/unit/file-permissions.test.ts
@@ -6,6 +6,7 @@
 
 import { unitTest } from "../test.ts";
 import { assert, assertEquals } from "testing/asserts";
+import { join } from "../../src/deno_ral/path.ts";
 import {
   ensureUserWritable,
   safeModeFromFile,
@@ -69,6 +70,50 @@ unitTest(
         "Mode should be unchanged for already-writable file",
       );
     } finally {
+      Deno.removeSync(tempDir, { recursive: true });
+    }
+  },
+);
+
+// Simulates the Nix/deb scenario: Deno.copyFileSync from a read-only source
+// preserves the read-only mode on the copy. ensureUserWritable must fix it.
+unitTest(
+  "file-permissions - copyFileSync from read-only source then ensureUserWritable",
+  // deno-lint-ignore require-await
+  async () => {
+    if (Deno.build.os === "windows") return;
+
+    const tempDir = Deno.makeTempDirSync({ prefix: "quarto-perm-test" });
+    try {
+      // Create a "source resource" file and make it read-only
+      const src = join(tempDir, "source.lua");
+      Deno.writeTextFileSync(src, "-- filter code");
+      Deno.chmodSync(src, 0o444);
+
+      // Copy it (this is what quarto create does internally)
+      const dest = join(tempDir, "dest.lua");
+      Deno.copyFileSync(src, dest);
+
+      // Without the fix, dest inherits 0o444 from src
+      const modeBefore = safeModeFromFile(dest);
+      assert(modeBefore !== undefined);
+      assert(
+        (modeBefore! & 0o200) === 0,
+        "Copied file should inherit read-only mode from source",
+      );
+
+      // Apply the fix
+      ensureUserWritable(dest);
+
+      const modeAfter = safeModeFromFile(dest);
+      assertEquals(
+        modeAfter,
+        0o644,
+        "Copied file should be user-writable after ensureUserWritable",
+      );
+    } finally {
+      // Restore write on source so cleanup succeeds
+      Deno.chmodSync(join(tempDir, "source.lua"), 0o644);
       Deno.removeSync(tempDir, { recursive: true });
     }
   },

--- a/tests/unit/file-permissions.test.ts
+++ b/tests/unit/file-permissions.test.ts
@@ -14,8 +14,6 @@ import {
   safeModeFromFile,
 } from "../../src/deno_ral/fs.ts";
 
-const permContext = { ignore: isWindows };
-
 function writeFile(dir: string, name: string, content: string, mode: number): string {
   const path = join(dir, name);
   Deno.writeTextFileSync(path, content);
@@ -38,7 +36,7 @@ unitTest(
     assertEquals(safeModeFromFile(file), 0o644,
       "Mode should be exactly 0o644 (0o444 | 0o200) — only user write bit added");
   }),
-  permContext,
+  { ignore: isWindows },
 );
 
 unitTest(
@@ -53,7 +51,7 @@ unitTest(
     assertEquals(safeModeFromFile(file), modeBefore,
       "Mode should be unchanged for already-writable file");
   }),
-  permContext,
+  { ignore: isWindows },
 );
 
 // Simulates the Nix/deb scenario: Deno.copyFileSync from a read-only source
@@ -81,5 +79,5 @@ unitTest(
     assertEquals(safeModeFromFile(dest), 0o644,
       "Copied file should be user-writable after ensureUserWritable");
   }),
-  permContext,
+  { ignore: isWindows },
 );

--- a/tests/unit/file-permissions.test.ts
+++ b/tests/unit/file-permissions.test.ts
@@ -12,12 +12,12 @@ import {
   safeModeFromFile,
 } from "../../src/deno_ral/fs.ts";
 
+const isWindows = Deno.build.os === "windows";
+
 unitTest(
   "file-permissions - ensureUserWritable fixes read-only files",
   // deno-lint-ignore require-await
   async () => {
-    if (Deno.build.os === "windows") return;
-
     const tempDir = Deno.makeTempDirSync({ prefix: "quarto-perm-test" });
     try {
       const testFile = join(tempDir, "readonly.txt");
@@ -45,14 +45,13 @@ unitTest(
       Deno.removeSync(tempDir, { recursive: true });
     }
   },
+  { ignore: isWindows },
 );
 
 unitTest(
   "file-permissions - ensureUserWritable leaves writable files unchanged",
   // deno-lint-ignore require-await
   async () => {
-    if (Deno.build.os === "windows") return;
-
     const tempDir = Deno.makeTempDirSync({ prefix: "quarto-perm-test" });
     try {
       const testFile = join(tempDir, "writable.txt");
@@ -73,6 +72,7 @@ unitTest(
       Deno.removeSync(tempDir, { recursive: true });
     }
   },
+  { ignore: isWindows },
 );
 
 // Simulates the Nix/deb scenario: Deno.copyFileSync from a read-only source
@@ -81,8 +81,6 @@ unitTest(
   "file-permissions - copyFileSync from read-only source then ensureUserWritable",
   // deno-lint-ignore require-await
   async () => {
-    if (Deno.build.os === "windows") return;
-
     const tempDir = Deno.makeTempDirSync({ prefix: "quarto-perm-test" });
     try {
       // Create a "source resource" file and make it read-only
@@ -117,4 +115,5 @@ unitTest(
       Deno.removeSync(tempDir, { recursive: true });
     }
   },
+  { ignore: isWindows },
 );

--- a/tests/unit/file-permissions.test.ts
+++ b/tests/unit/file-permissions.test.ts
@@ -20,7 +20,7 @@ unitTest(
 
     const tempDir = Deno.makeTempDirSync({ prefix: "quarto-perm-test" });
     try {
-      const testFile = `${tempDir}/readonly.txt`;
+      const testFile = join(tempDir, "readonly.txt");
       Deno.writeTextFileSync(testFile, "test content");
 
       // Make file read-only (simulate system-installed resource)
@@ -55,7 +55,7 @@ unitTest(
 
     const tempDir = Deno.makeTempDirSync({ prefix: "quarto-perm-test" });
     try {
-      const testFile = `${tempDir}/writable.txt`;
+      const testFile = join(tempDir, "writable.txt");
       Deno.writeTextFileSync(testFile, "test content");
       Deno.chmodSync(testFile, 0o644);
 

--- a/tests/unit/file-permissions.test.ts
+++ b/tests/unit/file-permissions.test.ts
@@ -1,7 +1,7 @@
 /*
  * file-permissions.test.ts
  *
- * Copyright (C) 2020-2025 Posit Software, PBC
+ * Copyright (C) 2020-2026 Posit Software, PBC
  */
 
 import { unitTest } from "../test.ts";
@@ -35,10 +35,10 @@ unitTest(
       ensureUserWritable(testFile);
 
       const modeAfter = safeModeFromFile(testFile);
-      assert(modeAfter !== undefined);
-      assert(
-        (modeAfter! & 0o200) !== 0,
-        "File should be user-writable after fix",
+      assertEquals(
+        modeAfter,
+        0o644,
+        "Mode should be exactly 0o644 (0o444 | 0o200) — only user write bit added",
       );
     } finally {
       Deno.removeSync(tempDir, { recursive: true });

--- a/tests/unit/file-permissions.test.ts
+++ b/tests/unit/file-permissions.test.ts
@@ -5,30 +5,16 @@
  */
 
 import { unitTest } from "../test.ts";
+import { withTempDir } from "../utils.ts";
 import { assert, assertEquals } from "testing/asserts";
 import { join } from "../../src/deno_ral/path.ts";
+import { isWindows } from "../../src/deno_ral/platform.ts";
 import {
   ensureUserWritable,
   safeModeFromFile,
 } from "../../src/deno_ral/fs.ts";
 
-const isWindows = Deno.build.os === "windows";
 const permContext = { ignore: isWindows };
-
-function withTempDir(fn: (dir: string) => void) {
-  const tempDir = Deno.makeTempDirSync({ prefix: "quarto-perm-test" });
-  try {
-    fn(tempDir);
-  } finally {
-    // Ensure all files are writable so cleanup succeeds (e.g. read-only sources)
-    for (const entry of Deno.readDirSync(tempDir)) {
-      try {
-        Deno.chmodSync(join(tempDir, entry.name), 0o644);
-      } catch { /* best effort */ }
-    }
-    Deno.removeSync(tempDir, { recursive: true });
-  }
-}
 
 function writeFile(dir: string, name: string, content: string, mode: number): string {
   const path = join(dir, name);
@@ -86,6 +72,9 @@ unitTest(
     const modeBefore = safeModeFromFile(dest);
     assert(modeBefore !== undefined);
     assert((modeBefore! & 0o200) === 0, "Copied file should inherit read-only mode from source");
+
+    // Make source writable so cleanup succeeds
+    Deno.chmodSync(src, 0o644);
 
     ensureUserWritable(dest);
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -20,6 +20,18 @@ export function inTempDirectory(fn: (dir: string) => unknown): unknown {
   return fn(dir);
 }
 
+export function withTempDir(
+  fn: (dir: string) => void,
+  prefix = "quarto-test",
+) {
+  const dir = Deno.makeTempDirSync({ prefix });
+  try {
+    fn(dir);
+  } finally {
+    Deno.removeSync(dir, { recursive: true });
+  }
+}
+
 // Find a _quarto.yaml file in the directory hierarchy of the input file
 export function findProjectDir(input: string, until?: RegExp | undefined): string | undefined {
   let dir = dirname(input);


### PR DESCRIPTION
Files copied from installed resources may have read-only permissions,
but users expect to edit files scaffolded into their project. Add
ensureUserWritable() after copy operations in both the extension
creation (artifact-shared.ts) and project creation (project-create.ts)
code paths.

https://claude.ai/code/session_01YFGmv1DBGcxDsQQJ2ZRhj7